### PR TITLE
Support CORS, and parse the incoming JSON as required

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,37 @@
 {
   "name": "graphql-mock-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "GraphQL Mock Server",
   "scripts": {
     "tsc": "tsc --noEmit"
   },
   "@pika/pack": {
     "pipeline": [
-      ["@pika/plugin-ts-standard-pkg"],
-      ["@pika/plugin-build-node"],
-      ["@pika/plugin-simple-bin", { "bin": "graphql-mock-server" }],
-      ["@pika/plugin-simple-bin", { "bin": "gms" }]
+      [
+        "@pika/plugin-ts-standard-pkg"
+      ],
+      [
+        "@pika/plugin-build-node"
+      ],
+      [
+        "@pika/plugin-simple-bin",
+        {
+          "bin": "graphql-mock-server"
+        }
+      ],
+      [
+        "@pika/plugin-simple-bin",
+        {
+          "bin": "gms"
+        }
+      ]
     ]
   },
   "dependencies": {
     "apollo-server-express": "2.17.0",
     "body-parser": "1.19.0",
     "commander": "2.20.3",
+    "cors": "^2.8.5",
     "express": "4.17.1",
     "graphql": "14.7.0",
     "lunar-core": "1.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import { ApolloServer, makeExecutableSchema } from 'apollo-server-express';
 import bodyParser from 'body-parser';
 import program from 'commander';
 import express from 'express';
+import { CorsOptions } from 'cors';
+
 import fs from 'fs';
 import {
   addMockFunctionsToSchema,
@@ -43,6 +45,24 @@ export default async function() {
   const app = express();
   const server = new ApolloServer({ schema });
 
+  const cors: CorsOptions = {
+    origin: [
+      `http://localhost:${port}`,
+      'http://localhost:3000',
+      'http://localhost:7000',
+      'http://localhost:8000',
+      'http://localhost:8080',
+      'http://localhost:9000',
+      'http://localhost:9090',
+    ],
+    methods: ['POST', 'GET', 'OPTIONS'],
+    preflightContinue: false,
+    optionsSuccessStatus: 204,
+    credentials: true,
+  };
+    
+  app.use(bodyParser.json())
+
   app.post('/mock', (req, res) => {
     currentMocks.push(deserialize(req.body));
     addMockFunctionsToSchema({ schema, mocks: currentMocks });
@@ -55,7 +75,7 @@ export default async function() {
     res.sendStatus(200);
   });
 
-  server.applyMiddleware({ app });
+  server.applyMiddleware({ app, cors });
 
   app.listen({ port }, () => {
     console.log(`🐬  GraphQL Mock Server running at http://localhost:${port}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1826,6 +1826,14 @@ cors@^2.8.4:
     object-assign "^4"
     vary "^1"
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"


### PR DESCRIPTION
Using the mock server from clients in modern browsers is very difficult without CORS support.
This PR adds explicit permission from the most common port numbers for local development on `localhost`.
Also added the JSON `bodyParser` which is now required in Express request handling for incoming JSON bodies.
Bumped the version number.